### PR TITLE
Update Dockerfile: Added CORS and sqlite command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
 FROM alpine:3.17
 ARG BUILDARCH
 ARG PB_VERSION=0.22.18
+
 RUN apk add --no-cache \
     unzip \
-    ca-certificates
+    ca-certificates \
+    sqlite
 
 ADD https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/pocketbase_${PB_VERSION}_linux_${BUILDARCH}.zip /tmp/pb.zip
 RUN unzip /tmp/pb.zip -d /app/
 RUN rm /tmp/pb.zip
 EXPOSE 8080
-CMD ["/app/pocketbase", "serve", "--http=0.0.0.0:8080"]
+
+ENV ORIGINS=""  # Default to allow all origins if no value is provided
+CMD ["/app/pocketbase", "serve", "--http=0.0.0.0:8080", "--origins=${ORIGINS}"]


### PR DESCRIPTION
Allow all origins by default; support dynamic origins via Docker Compose

- Set default `ORIGINS` to an empty string in the Dockerfile, allowing all origins if not overridden.
- Updated CMD instruction to handle dynamic `ORIGINS` value from Docker Compose.
- Ensured PocketBase will use whatever origins are passed in the Docker Compose file or default to allowing all.