### PR TITLE
feat: change from cmd to entrypoint to support encryption env, fixes #31

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 FROM alpine:3.17
+
 ARG BUILDARCH
 ARG PB_VERSION=0.22.18
+
 RUN apk add --no-cache \
-    unzip \
-    ca-certificates
+  unzip \
+  ca-certificates
 
 ADD https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/pocketbase_${PB_VERSION}_linux_${BUILDARCH}.zip /tmp/pb.zip
+
 RUN unzip /tmp/pb.zip -d /app/
 RUN rm /tmp/pb.zip
+
 EXPOSE 8080
-CMD ["/app/pocketbase", "serve", "--http=0.0.0.0:8080"]
+
+ENTRYPOINT ["/app/pocketbase", "serve", "--http=0.0.0.0:8080"]


### PR DESCRIPTION
Change from `CMD` to `ENTRYPOINT` to allow [settings encryption](https://pocketbase.io/docs/going-to-production/#enable-settings-encryption) for Pocketbase.
I will also update the coolify template for pocketbase once this gets merged.