### PR TITLE
Update Pocketbase & Alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM alpine:3.17
 
 ARG BUILDARCH
-ARG PB_VERSION=0.24.3
+ARG PB_VERSION=0.24.4
 
 RUN apk add --no-cache \
   unzip \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.17
+FROM alpine:3.21
 
 ARG BUILDARCH
 ARG PB_VERSION=0.24.4

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# PocketBase at Coolify 0.24.3
+# PocketBase at Coolify 0.24.4
 > [Coolify](https://github.com/coollabsio/coolify) x [Pocketbase](https://pocketbase.io/) releases to AMD & ARM architectures.
 
 Want to easily host Pocketbase on your own server? Use [Coolify](https://coolify.io)! 🚀
@@ -16,6 +16,6 @@ Want to easily host Pocketbase on your own server? Use [Coolify](https://coolify
 
 ## <a name="release-process"></a>Release process
 1. Propose an update in [Issues](https://github.com/coollabsio/pocketbase/issues).
-2. Then changes will be applied `PB_VERSION=0.24.3` inside [Dockerfile](./Dockerfile#LL3C5-L3C22).
+2. Then changes will be applied `PB_VERSION=0.24.4` inside [Dockerfile](./Dockerfile#LL3C5-L3C22).
 3. Create a new Release with the exact version number.
 4. Wait & Enjoy 🎉.


### PR DESCRIPTION
Update pocketbase to 0.24.4
Update alpine to 3.21
Medium vulnerabilities found in 3.17