### PR TITLE
Added Healthcheck 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: "coollabsio/pocketbase"
+  IMAGE_NAME: "frankdierolf/pocketbase"
 
 jobs:
   amd64:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ ARG PB_VERSION=0.28.1
 
 RUN apk add --no-cache \
   unzip \
-  ca-certificates
+  ca-certificates \
+  curl \
+  wget
 
 ADD https://github.com/pocketbase/pocketbase/releases/download/v${PB_VERSION}/pocketbase_${PB_VERSION}_linux_${BUILDARCH}.zip /tmp/pb.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,8 @@ RUN rm /tmp/pb.zip
 
 EXPOSE 8080
 
+# Add healthcheck
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+  CMD curl --fail http://localhost:8080/api/health || exit 1
+
 ENTRYPOINT ["/app/pocketbase", "serve", "--http=0.0.0.0:8080"]


### PR DESCRIPTION
### Hola 👋

#### Problem  
Every time you spin up a PocketBaseInstant (e.g. on Coolify), you get that persistent **"not healthy"** warning — even though the app is running just fine.

#### Idea  
Let’s fix that so the container shows up as healthy when PocketBase is actually ready.

#### Solution  
- Added `curl` and `wget` to the container (needed for the health check logic).
- Added a Docker-native `HEALTHCHECK` that pings the `/api/health` endpoint — Coolify (and others) can now correctly detect when the service is up.

#### Healthcheck config (open for feedback):
```Dockerfile
HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
  CMD curl --fail http://localhost:8080/api/health || exit 1
````

#### To Discuss

* Is `30s` a good interval?
* Should we use different retry or timeout values?
* Any edge cases where this endpoint might mislead?

---

Let me know what you think! Happy to tweak the values or approach based on feedback.
If I would maintain this repo, I would merge it, alias lgtm. ^^ 
